### PR TITLE
Release v0.1.10

### DIFF
--- a/.licenseignore
+++ b/.licenseignore
@@ -7,3 +7,4 @@
 ./config/README.md
 ./CODE_OF_CONDUCT.md
 ./CONTRIBUTING.md
+./SECURITY.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.1.10
+
+TODO
+
 ## v0.1.9
 
 * Mu now has a CODE_OF_CONDUCT.md and CONTRIBUTING.md.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## v0.1.10
 
-TODO
+* New `PreRun` hook can be used to register a function to run immediately
+  before worker start.
+* The `Setup` hook has been renamed to `SetupWorkers`. **This is a breaking
+  change.** To upgrade, call `SetupWorkers` instead of `Setup` in your
+  application.
 
 ## v0.1.9
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-## Contributing to Mu
+# Contributing to Mu
 
 To contribute, fork the repository and submit a pull request.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ func main() {
     the framework. Hooks are called at specific points in the lifecycle of a
     microservice. You can use hooks to add custom functionality to your
     microservice. The example above uses two hooks, `ConfigSetup` and
-	`SetupWorkers`.
+    `SetupWorkers`.
 -   **Configuration** - Mu is designed to be configured using environment
     variables. This allows you to easily configure your microservice using
     Docker, Kubernetes, or any other container orchestration system.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ func main() {
 	s.ConfigSetup(func(c config.Config) error {
 		return c.NewString("MESSAGE", "Hello world!", "The message to print")
 	})
-	s.Setup(func(g worker.Group) error {
+	s.SetupWorkers(func(g worker.Group) error {
 		httpServer, err := http.NewServer()
 		if err != nil {
 			return err
@@ -61,7 +61,8 @@ func main() {
 -   **Hooks** - Mu uses hooks to allow you to easily extend the functionality of
     the framework. Hooks are called at specific points in the lifecycle of a
     microservice. You can use hooks to add custom functionality to your
-    microservice. The example above uses two hooks, `ConfigSetup` and `Setup`.
+    microservice. The example above uses two hooks, `ConfigSetup` and
+	`SetupWorkers`.
 -   **Configuration** - Mu is designed to be configured using environment
     variables. This allows you to easily configure your microservice using
     Docker, Kubernetes, or any other container orchestration system.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Mu Security Policy
+
+We want Mu to be safe and secure for everyone. We do this by following these
+practices:
+
+- **Dependencies**: Part of Mu's release process is to update all of its
+dependencies to the latest versions, including transitive dependencies.
+Additionally, we apply Dependabot to the repository, and if a security
+vulnerability is found in a dependency, we will update the dependency as soon
+as possible and release a new version of Mu.
+- **CodeQL**: We use CodeQL to scan the codebase for security vulnerabilities.
+Vulnerabilities of level HIGH or above are blockers to a release, and we will
+address these before releasing any new version of Mu.
+
+## Supported Versions
+
+The Mu team strives to maintain backward compatibility within major versions.
+This means that within a given major version, we do not backport bug fixes or
+security fixes. However, we will backport security fixes to the previous major
+version if possible. Versions older than the previous major version are not
+supported.
+
+## Reporting a Vulnerability
+
+Please report vulnerabilities to
+[neuralnorthwestllc+vuln@gmail.com](mailto:neuralnorthwestllc+vuln@gmail.com).

--- a/samples/basic/basic.go
+++ b/samples/basic/basic.go
@@ -30,11 +30,11 @@ import (
 //  - Define newBasicApp, which initializes the application:
 //    - Create a new service.Service
 //    - Register the configuration setup hook `configSetup`
-//    - Register the setup hook `setup`
+//    - Register the worker setup hook `setupWorkers`
 //    - Register the cleanup hook `cleanup`
 //  - Define configSetup, which sets up the configuration:
 //    - Create a new string configuration variable `MESSAGE`
-//  - Define setup, which sets up the application:
+//  - Define setupWorkers, which sets up the application workers:
 //    - Create a new HTTP server
 //    - Register a handler for the `/hello` endpoint
 //    - Add the HTTP server to the worker group
@@ -60,7 +60,7 @@ func newBasicApp() (*BasicApp, error) {
 		Service: svc,
 	}
 	app.ConfigSetup(app.configSetup)
-	app.Setup(app.setup)
+	app.SetupWorkers(app.setupWorkers)
 	app.Cleanup(app.cleanup)
 	return app, nil
 }
@@ -70,8 +70,8 @@ func (a *BasicApp) configSetup(c config.Config) error {
 	return c.NewString("MESSAGE", "Hello, World!", "The message to print.")
 }
 
-// setup sets up the application.
-func (a *BasicApp) setup(workerGroup worker.Group) error {
+// setupWorkers sets up the application.
+func (a *BasicApp) setupWorkers(workerGroup worker.Group) error {
 	httpServer, err := http.NewServer()
 	if err != nil {
 		return err

--- a/samples/metrics/metrics.go
+++ b/samples/metrics/metrics.go
@@ -29,8 +29,8 @@ import (
 //  - Define MetricsApp, which embeds an instance of service.Service
 //  - Define newMetricsApp, which initializes the application:
 //    - Create a new service.Service
-//    - Register the setup hook `setup`
-//  - Define setup, which sets up the application:
+//    - Register the worker setup hook `setupWorkers`
+//  - Define setupWorkers, which sets up the application workers:
 //    - Create a new HTTP server
 //    - Register a handler for the `/hello` endpoint
 //    - Register a handler for the `/metrics` endpoint
@@ -58,12 +58,12 @@ func newMetricsApp() (*MetricsApp, error) {
 	app := &MetricsApp{
 		Service: svc,
 	}
-	app.Setup(app.setup)
+	app.SetupWorkers(app.setupWorkers)
 	return app, nil
 }
 
-// setup sets up the application.
-func (a *MetricsApp) setup(workerGroup worker.Group) error {
+// setupWorkers sets up the application.
+func (a *MetricsApp) setupWorkers(workerGroup worker.Group) error {
 	met, _ := metrics.New()
 	a.helloCounter = met.NewCounter("hello_counter", "Number of times the /hello endpoint has been called")
 	httpServer, err := http.NewServer()

--- a/service/README.md
+++ b/service/README.md
@@ -43,11 +43,11 @@ import (
 //  - Define newBasicApp, which initializes the application:
 //    - Create a new service.Service
 //    - Register the configuration setup hook `configSetup`
-//    - Register the setup hook `setup`
+//    - Register the worker setup hook `setupWorkers`
 //    - Register the cleanup hook `cleanup`
 //  - Define configSetup, which sets up the configuration:
 //    - Create a new string configuration variable `MESSAGE`
-//  - Define setup, which sets up the application:
+//  - Define setupWorkers, which sets up the application:
 //    - Create a new HTTP server
 //    - Register a handler for the `/hello` endpoint
 //    - Add the HTTP server to the worker group
@@ -73,7 +73,7 @@ func newBasicApp() (*BasicApp, error) {
 		Service: svc,
 	}
 	app.ConfigSetup(app.configSetup)
-	app.Setup(app.setup)
+	app.SetupWorkers(app.setupWorkers)
 	app.Cleanup(app.cleanup)
 	return app, nil
 }
@@ -83,8 +83,8 @@ func (a *BasicApp) configSetup(c config.Config) error {
 	return c.NewString("MESSAGE", "Hello, World!", "The message to print.")
 }
 
-// setup sets up the application.
-func (a *BasicApp) setup(workerGroup worker.Group) error {
+// setupWorkers sets up the application.
+func (a *BasicApp) setupWorkers(workerGroup worker.Group) error {
 	httpServer, err := http.NewServer()
 	if err != nil {
 		return err

--- a/service/hook.go
+++ b/service/hook.go
@@ -29,8 +29,8 @@ type ConfigSetupFunc func(c config.Config) error
 // PreRunFunc is a function that runs before the workers are started.
 type PreRunFunc func() error
 
-// SetupFunc is a function that sets up a service.
-type SetupFunc func(workerGroup worker.Group) error
+// SetupWorkersFunc is a function that sets up workers for the service.
+type SetupWorkersFunc func(workerGroup worker.Group) error
 
 // SetupHTTPFunc is a function that sets up a service HTTP server.
 type SetupHTTPFunc func(server *http.Server) error
@@ -39,13 +39,13 @@ type Hooks interface {
 	Cleanup(f CleanupFunc)
 	ConfigSetup(f ConfigSetupFunc)
 	PreRun(f PreRunFunc)
-	Setup(f SetupFunc)
+	SetupWorkers(f SetupWorkersFunc)
 	SetupHTTP(f SetupHTTPFunc)
 
 	invokeCleanup() error
 	invokeConfigSetup(c config.Config) error
 	invokePreRun() error
-	invokeSetup(workerGroup worker.Group) error
+	invokeSetupWorkers(workerGroup worker.Group) error
 	invokeSetupHTTP() (*http.Server, error)
 }
 
@@ -57,8 +57,8 @@ type hookstruct struct {
 	configSetup ConfigSetupFunc
 	// prerun is the prerun hook.
 	prerun PreRunFunc
-	// setup is the setup hook.
-	setup SetupFunc
+	// setupWorkers is the setupWorkers hook.
+	setupWorkers SetupWorkersFunc
 	// setupHTTP is the setup HTTP hook.
 	setupHTTP SetupHTTPFunc
 	// httpNewServer is a function that creates a new HTTP server. This is used
@@ -73,7 +73,7 @@ func (h *hookstruct) Cleanup(f CleanupFunc) {
 	h.cleanup = f
 }
 
-// SetupConfig registers a setup configuration hook.
+// ConfigSetup registers a configuration setup hook.
 func (h *hookstruct) ConfigSetup(f ConfigSetupFunc) {
 	h.configSetup = f
 }
@@ -83,9 +83,9 @@ func (h *hookstruct) PreRun(f PreRunFunc) {
 	h.prerun = f
 }
 
-// Setup registers a setup hook.
-func (h *hookstruct) Setup(f SetupFunc) {
-	h.setup = f
+// SetupWorkers registers a worker setup hook.
+func (h *hookstruct) SetupWorkers(f SetupWorkersFunc) {
+	h.setupWorkers = f
 }
 
 // SetupHTTP registers a setup HTTP hook.
@@ -117,10 +117,10 @@ func (h *hookstruct) invokePreRun() error {
 	return nil
 }
 
-// invokeSetup invokes the setup hook.
-func (h *hookstruct) invokeSetup(workerGroup worker.Group) error {
-	if h.setup != nil {
-		return h.setup(workerGroup)
+// invokeSetupWorkers invokes the setup hook.
+func (h *hookstruct) invokeSetupWorkers(workerGroup worker.Group) error {
+	if h.setupWorkers != nil {
+		return h.setupWorkers(workerGroup)
 	}
 	return nil
 }

--- a/service/hook_test.go
+++ b/service/hook_test.go
@@ -30,7 +30,7 @@ func Test_hooks_NoHooks(t *testing.T) {
 	if err := h.invokeConfigSetup(nil); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if err := h.invokeSetup(nil); err != nil {
+	if err := h.invokeSetupWorkers(nil); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if err := h.invokeCleanup(); err != nil {
@@ -89,20 +89,20 @@ func Test_hooks_InvokePreRun(t *testing.T) {
 	}
 }
 
-// Test_hooks_InvokeSetup tests that the setup hook is invoked.
-func Test_hooks_InvokeSetup(t *testing.T) {
+// Test_hooks_InvokeSetupWorkers tests that the setupWorkers hook is invoked.
+func Test_hooks_InvokeSetupWorkers(t *testing.T) {
 	t.Parallel()
 	wasInvoked := false
 	h := &hookstruct{}
-	h.Setup(func(workerGroup worker.Group) error {
+	h.SetupWorkers(func(workerGroup worker.Group) error {
 		wasInvoked = true
 		return nil
 	})
-	if err := h.invokeSetup(nil); err != nil {
+	if err := h.invokeSetupWorkers(nil); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if !wasInvoked {
-		t.Error("expected setup hook to be invoked")
+		t.Error("expected setupWorkers hook to be invoked")
 	}
 }
 

--- a/service/hook_test.go
+++ b/service/hook_test.go
@@ -72,6 +72,23 @@ func Test_hooks_InvokeConfigSetup(t *testing.T) {
 	}
 }
 
+// Test_hooks_InvokePreRun tests that the pre-run hook is invoked.
+func Test_hooks_InvokePreRun(t *testing.T) {
+	t.Parallel()
+	wasInvoked := false
+	h := &hookstruct{}
+	h.PreRun(func() error {
+		wasInvoked = true
+		return nil
+	})
+	if err := h.invokePreRun(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !wasInvoked {
+		t.Error("expected pre-run hook to be invoked")
+	}
+}
+
 // Test_hooks_InvokeSetup tests that the setup hook is invoked.
 func Test_hooks_InvokeSetup(t *testing.T) {
 	t.Parallel()

--- a/service/main_test.go
+++ b/service/main_test.go
@@ -41,7 +41,7 @@ func Test_Main(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New returned an error: %v", err)
 	}
-	svc.Setup(func(group worker.Group) error {
+	svc.SetupWorkers(func(group worker.Group) error {
 		return group.Add("worker", &testTraceWorker{ran: &workerRan})
 	})
 	if err := svc.Main(); err != nil {

--- a/service/run.go
+++ b/service/run.go
@@ -34,7 +34,7 @@ func (s *Service) Run() (status error) {
 		return err
 	}
 	workerGroup := worker.NewGroup()
-	if err := s.invokeSetup(workerGroup); err != nil {
+	if err := s.invokeSetupWorkers(workerGroup); err != nil {
 		return err
 	}
 	defer func() {

--- a/service/run_test.go
+++ b/service/run_test.go
@@ -63,18 +63,18 @@ func Test_run_MockMode(t *testing.T) {
 // Test_run_Hooks_Case is a test case for Test_run_Hooks. It indicates which,
 // if any, hooks should return errors.
 type Test_run_Hooks_Case struct {
-	name                  string
-	cleanupErr            error
-	configSetupErr        error
-	prerunErr             error
-	setupErr              error
-	setupHTTPErr          error
-	expectedErr           string
-	cleanupWasInvoked     bool
-	configSetupWasInvoked bool
-	prerunWasInvoked      bool
-	setupWasInvoked       bool
-	setupHTTPWasInvoked   bool
+	name                   string
+	cleanupErr             error
+	configSetupErr         error
+	prerunErr              error
+	setupWorkersErr        error
+	setupHTTPErr           error
+	expectedErr            string
+	cleanupWasInvoked      bool
+	configSetupWasInvoked  bool
+	prerunWasInvoked       bool
+	setupWorkersWasInvoked bool
+	setupHTTPWasInvoked    bool
 }
 
 // Test_run_Hooks tests that the service runs with hooks.
@@ -82,87 +82,87 @@ func Test_run_Hooks(t *testing.T) {
 	t.Parallel()
 	testCases := []Test_run_Hooks_Case{
 		{
-			name:                  "no errors",
-			cleanupErr:            nil,
-			configSetupErr:        nil,
-			prerunErr:             nil,
-			setupErr:              nil,
-			setupHTTPErr:          nil,
-			cleanupWasInvoked:     true,
-			configSetupWasInvoked: true,
-			prerunWasInvoked:      true,
-			setupWasInvoked:       true,
-			setupHTTPWasInvoked:   true,
+			name:                   "no errors",
+			cleanupErr:             nil,
+			configSetupErr:         nil,
+			prerunErr:              nil,
+			setupWorkersErr:        nil,
+			setupHTTPErr:           nil,
+			cleanupWasInvoked:      true,
+			configSetupWasInvoked:  true,
+			prerunWasInvoked:       true,
+			setupWorkersWasInvoked: true,
+			setupHTTPWasInvoked:    true,
 		},
 		{
-			name:                  "cleanup error",
-			cleanupErr:            fmt.Errorf("cleanup error"),
-			configSetupErr:        nil,
-			prerunErr:             nil,
-			setupErr:              nil,
-			setupHTTPErr:          nil,
-			expectedErr:           "cleanup error",
-			cleanupWasInvoked:     true,
-			configSetupWasInvoked: true,
-			prerunWasInvoked:      true,
-			setupWasInvoked:       true,
-			setupHTTPWasInvoked:   true,
+			name:                   "cleanup error",
+			cleanupErr:             fmt.Errorf("cleanup error"),
+			configSetupErr:         nil,
+			prerunErr:              nil,
+			setupWorkersErr:        nil,
+			setupHTTPErr:           nil,
+			expectedErr:            "cleanup error",
+			cleanupWasInvoked:      true,
+			configSetupWasInvoked:  true,
+			prerunWasInvoked:       true,
+			setupWorkersWasInvoked: true,
+			setupHTTPWasInvoked:    true,
 		},
 		{
-			name:                  "config setup error",
-			cleanupErr:            nil,
-			configSetupErr:        fmt.Errorf("config setup error"),
-			prerunErr:             nil,
-			setupErr:              nil,
-			setupHTTPErr:          nil,
-			expectedErr:           "config setup error",
-			cleanupWasInvoked:     false,
-			configSetupWasInvoked: true,
-			prerunWasInvoked:      false,
-			setupWasInvoked:       false,
-			setupHTTPWasInvoked:   false,
+			name:                   "config setup error",
+			cleanupErr:             nil,
+			configSetupErr:         fmt.Errorf("config setup error"),
+			prerunErr:              nil,
+			setupWorkersErr:        nil,
+			setupHTTPErr:           nil,
+			expectedErr:            "config setup error",
+			cleanupWasInvoked:      false,
+			configSetupWasInvoked:  true,
+			prerunWasInvoked:       false,
+			setupWorkersWasInvoked: false,
+			setupHTTPWasInvoked:    false,
 		},
 		{
-			name:                  "prerun error",
-			cleanupErr:            nil,
-			configSetupErr:        nil,
-			prerunErr:             fmt.Errorf("prerun error"),
-			setupErr:              nil,
-			setupHTTPErr:          nil,
-			expectedErr:           "prerun error",
-			cleanupWasInvoked:     true,
-			configSetupWasInvoked: true,
-			prerunWasInvoked:      true,
-			setupWasInvoked:       true,
-			setupHTTPWasInvoked:   true,
+			name:                   "prerun error",
+			cleanupErr:             nil,
+			configSetupErr:         nil,
+			prerunErr:              fmt.Errorf("prerun error"),
+			setupWorkersErr:        nil,
+			setupHTTPErr:           nil,
+			expectedErr:            "prerun error",
+			cleanupWasInvoked:      true,
+			configSetupWasInvoked:  true,
+			prerunWasInvoked:       true,
+			setupWorkersWasInvoked: true,
+			setupHTTPWasInvoked:    true,
 		},
 		{
-			name:                  "setup error",
-			cleanupErr:            nil,
-			configSetupErr:        nil,
-			prerunErr:             nil,
-			setupErr:              fmt.Errorf("setup error"),
-			setupHTTPErr:          nil,
-			expectedErr:           "setup error",
-			cleanupWasInvoked:     false,
-			configSetupWasInvoked: true,
-			prerunWasInvoked:      false,
-			setupWasInvoked:       true,
-			setupHTTPWasInvoked:   false,
+			name:                   "setup workers error",
+			cleanupErr:             nil,
+			configSetupErr:         nil,
+			prerunErr:              nil,
+			setupWorkersErr:        fmt.Errorf("setup workers error"),
+			setupHTTPErr:           nil,
+			expectedErr:            "setup workers error",
+			cleanupWasInvoked:      false,
+			configSetupWasInvoked:  true,
+			prerunWasInvoked:       false,
+			setupWorkersWasInvoked: true,
+			setupHTTPWasInvoked:    false,
 		},
 		{
-			name:                  "setup HTTP error",
-			cleanupErr:            nil,
-			configSetupErr:        nil,
-			prerunErr:             nil,
-			setupErr:              nil,
-			setupHTTPErr:          fmt.Errorf("setup HTTP error"),
-			expectedErr:           "setup HTTP error",
-			cleanupWasInvoked:     true,
-			configSetupWasInvoked: true,
-			prerunWasInvoked:      false,
-			setupWasInvoked:       true,
-			setupHTTPWasInvoked:   true,
+			name:                   "setup HTTP error",
+			cleanupErr:             nil,
+			configSetupErr:         nil,
+			prerunErr:              nil,
+			setupWorkersErr:        nil,
+			setupHTTPErr:           fmt.Errorf("setup HTTP error"),
+			expectedErr:            "setup HTTP error",
+			cleanupWasInvoked:      true,
+			configSetupWasInvoked:  true,
+			prerunWasInvoked:       false,
+			setupWorkersWasInvoked: true,
+			setupHTTPWasInvoked:    true,
 		},
 	}
 	for _, tc := range testCases {
@@ -174,7 +174,7 @@ func Test_run_Hooks(t *testing.T) {
 			cleanupWasInvoked := false
 			configSetupWasInvoked := false
 			prerunWasInvoked := false
-			setupWasInvoked := false
+			setupWorkersWasInvoked := false
 			setupHTTPWasInvoked := false
 			svc.Cleanup(func() error {
 				cleanupWasInvoked = true
@@ -190,9 +190,9 @@ func Test_run_Hooks(t *testing.T) {
 				svc.Cancel()
 				return tc.prerunErr
 			})
-			svc.Setup(func(worker.Group) error {
-				setupWasInvoked = true
-				return tc.setupErr
+			svc.SetupWorkers(func(worker.Group) error {
+				setupWorkersWasInvoked = true
+				return tc.setupWorkersErr
 			})
 			svc.SetupHTTP(func(*http.Server) error {
 				setupHTTPWasInvoked = true
@@ -217,8 +217,8 @@ func Test_run_Hooks(t *testing.T) {
 			if prerunWasInvoked != tc.prerunWasInvoked {
 				t.Errorf("prerun hook was invoked: %t", prerunWasInvoked)
 			}
-			if setupWasInvoked != tc.setupWasInvoked {
-				t.Errorf("setup hook was invoked: %t", setupWasInvoked)
+			if setupWorkersWasInvoked != tc.setupWorkersWasInvoked {
+				t.Errorf("setup hook was invoked: %t", setupWorkersWasInvoked)
 			}
 			if setupHTTPWasInvoked != tc.setupHTTPWasInvoked {
 				t.Errorf("setup HTTP hook was invoked: %t", setupHTTPWasInvoked)
@@ -296,7 +296,7 @@ func Test_run_Workers(t *testing.T) {
 			if err != nil {
 				t.Fatalf("New returned an error: %v", err)
 			}
-			svc.Setup(func(group worker.Group) error {
+			svc.SetupWorkers(func(group worker.Group) error {
 				for i, w := range testCase.workers {
 					if err := group.Add(fmt.Sprintf("worker-%d", i), w); err != nil {
 						return err
@@ -356,7 +356,7 @@ func Test_run_interrupt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New returned an error: %v", err)
 	}
-	svc.Setup(func(group worker.Group) error {
+	svc.SetupWorkers(func(group worker.Group) error {
 		return group.Add("wait-worker", newTestWaitWorker(t))
 	})
 	svc.sigChan <- syscall.SIGINT

--- a/service/service.go
+++ b/service/service.go
@@ -44,9 +44,6 @@ type Service struct {
 	newLogger func() (logging.Logger, error)
 	// sigChan is the channel for signals.
 	sigChan chan os.Signal
-	// stopImmediately is true if the service should stop immediately. This is
-	// used for testing.
-	stopImmediately bool
 }
 
 // New returns a new service.

--- a/version.go
+++ b/version.go
@@ -14,7 +14,7 @@
 
 package mu
 
-const version = "v0.1.9"
+const version = "v0.1.10"
 const _ = version
 
 // Version returns the version of mu.


### PR DESCRIPTION
## v0.1.10

* New `PreRun` hook can be used to register a function to run immediately
  before worker start.
* The `Setup` hook has been renamed to `SetupWorkers`. **This is a breaking
  change.** To upgrade, call `SetupWorkers` instead of `Setup` in your
  application.