### PR TITLE
Release v0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 * The `Setup` hook has been renamed to `SetupWorkers`. **This is a breaking
   change.** To upgrade, call `SetupWorkers` instead of `Setup` in your
   application.
+* The `ConfigSetup` hook has been renamed to `SetupConfig`. **This is a
+  breaking change.** To upgrade, call `SetupConfig` instead of `ConfigSetup`
+  in your application.
+* New `Level` and `SetLevel` methods for `logging.Logger`.
+* New `WithLevel` option for `logging.New`.
 
 ## v0.1.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.1.11
+
+* The `ConfigSetup` hook has been renamed to `SetupConfig`. **This is a
+  breaking change.** To upgrade, call `SetupConfig` instead of `ConfigSetup`
+  in your application.
+* New `Level` and `SetLevel` methods for `logging.Logger`.
+* New `WithLevel` option for `logging.New`.
+
 ## v0.1.10
 
 * New `PreRun` hook can be used to register a function to run immediately
@@ -5,11 +13,6 @@
 * The `Setup` hook has been renamed to `SetupWorkers`. **This is a breaking
   change.** To upgrade, call `SetupWorkers` instead of `Setup` in your
   application.
-* The `ConfigSetup` hook has been renamed to `SetupConfig`. **This is a
-  breaking change.** To upgrade, call `SetupConfig` instead of `ConfigSetup`
-  in your application.
-* New `Level` and `SetLevel` methods for `logging.Logger`.
-* New `WithLevel` option for `logging.New`.
 
 ## v0.1.9
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ import (
 
 func main() {
 	s, _ := service.New("hello-service")
-	s.ConfigSetup(func(c config.Config) error {
+	s.SetupConfig(func(c config.Config) error {
 		return c.NewString("MESSAGE", "Hello world!", "The message to print")
 	})
 	s.SetupWorkers(func(g worker.Group) error {
@@ -61,7 +61,7 @@ func main() {
 -   **Hooks** - Mu uses hooks to allow you to easily extend the functionality of
     the framework. Hooks are called at specific points in the lifecycle of a
     microservice. You can use hooks to add custom functionality to your
-    microservice. The example above uses two hooks, `ConfigSetup` and
+    microservice. The example above uses two hooks, `SetupConfig` and
     `SetupWorkers`.
 -   **Configuration** - Mu is designed to be configured using environment
     variables. This allows you to easily configure your microservice using

--- a/logging/adapter.go
+++ b/logging/adapter.go
@@ -19,25 +19,10 @@ import (
 	"log"
 )
 
-// AdaptedLevel is a log level that can be adapted to the standard library
-// logger.
-type AdaptedLevel int
-
-const (
-	// AdaptedLevelDebug is the debug level.
-	AdaptedLevelDebug AdaptedLevel = iota
-	// AdaptedLevelInfo is the info level.
-	AdaptedLevelInfo
-	// AdaptedLevelWarn is the warn level.
-	AdaptedLevelWarn
-	// AdaptedLevelError is the error level.
-	AdaptedLevelError
-)
-
 // Adapter adapts the Mu logger to the standard library logger.
 type Adapter struct {
 	// level is the log level to adapt to.
-	level AdaptedLevel
+	level Level
 	// logger is the Mu logger.
 	logger Logger
 	// buffer is a buffer for accumulating log lines.
@@ -46,7 +31,7 @@ type Adapter struct {
 
 // NewAdapter creates a new Adapter and returns a log.Logger that writes to it.
 // The level controls how the log messages are written to the Mu logger.
-func NewAdapter(logger Logger, level AdaptedLevel) *log.Logger {
+func NewAdapter(logger Logger, level Level) *log.Logger {
 	return log.New(&Adapter{
 		level:  level,
 		logger: logger,
@@ -65,13 +50,13 @@ func (a *Adapter) Write(b []byte) (int, error) {
 		// Remove the trailing newline
 		line = line[:len(line)-1]
 		switch a.level {
-		case AdaptedLevelDebug:
+		case DebugLevel:
 			a.logger.Debug(string(line))
-		case AdaptedLevelInfo:
+		case InfoLevel:
 			a.logger.Info(string(line))
-		case AdaptedLevelWarn:
+		case WarnLevel:
 			a.logger.Warn(string(line))
-		case AdaptedLevelError:
+		case ErrorLevel:
 			a.logger.Error(string(line))
 		}
 	}

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -16,8 +16,26 @@ package logging
 
 //go:generate go run github.com/golang/mock/mockgen@v1.6.0 -package mock -destination mock/logger.go github.com/neuralnorthwest/mu/logging Logger
 
+// Level is the level of logging.
+type Level int
+
+const (
+	// DebugLevel is the debug level.
+	DebugLevel Level = iota
+	// InfoLevel is the info level.
+	InfoLevel
+	// WarnLevel is the warn level.
+	WarnLevel
+	// ErrorLevel is the error level.
+	ErrorLevel
+)
+
 // Logger is the interface for logging.
 type Logger interface {
+	// Level returns the logging level.
+	Level() Level
+	// SetLevel sets the logging level.
+	SetLevel(level Level)
 	// DPanic logs a panic message and panics in development mode.
 	DPanic(args ...interface{})
 	// DPanicf logs a panic message with formatting and panics in development mode.
@@ -80,7 +98,17 @@ type Logger interface {
 	With(args ...interface{}) Logger
 }
 
+// Option is a function that configures a logger.
+type Option func(Logger)
+
+// WithLevel returns an option that sets the logging level.
+func WithLevel(level Level) Option {
+	return func(logger Logger) {
+		logger.SetLevel(level)
+	}
+}
+
 // New returns a new logger based on zap.
-func New() (Logger, error) {
-	return NewZapLogger()
+func New(opts ...Option) (Logger, error) {
+	return NewZapLogger(opts...)
 }

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -55,3 +55,33 @@ func Test_With(t *testing.T) {
 		t.Fatal("zapLogger.GetZap returned a nil logger")
 	}
 }
+
+// Test_Level tests the Level/SetLevel functions.
+func Test_Level(t *testing.T) {
+	t.Parallel()
+	logger, err := New()
+	if err != nil {
+		t.Fatalf("New returned an error: %v", err)
+	}
+	if logger.Level() != InfoLevel {
+		t.Fatalf("Level returned %v, expected InfoLevel", logger.Level())
+	}
+	for _, level := range []Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel} {
+		logger.SetLevel(level)
+		if logger.Level() != level {
+			t.Fatalf("Level returned %v, expected %v", logger.Level(), level)
+		}
+	}
+}
+
+// Test_WithLevel tests the WithLevel option.
+func Test_WithLevel(t *testing.T) {
+	t.Parallel()
+	logger, err := New(WithLevel(DebugLevel))
+	if err != nil {
+		t.Fatalf("New returned an error: %v", err)
+	}
+	if logger.Level() != DebugLevel {
+		t.Fatalf("Level returned %v, expected DebugLevel", logger.Level())
+	}
+}

--- a/logging/mock/logger.go
+++ b/logging/mock/logger.go
@@ -364,6 +364,20 @@ func (mr *MockLoggerMockRecorder) Infow(arg0 interface{}, arg1 ...interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Infow", reflect.TypeOf((*MockLogger)(nil).Infow), varargs...)
 }
 
+// Level mocks base method.
+func (m *MockLogger) Level() logging.Level {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Level")
+	ret0, _ := ret[0].(logging.Level)
+	return ret0
+}
+
+// Level indicates an expected call of Level.
+func (mr *MockLoggerMockRecorder) Level() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Level", reflect.TypeOf((*MockLogger)(nil).Level))
+}
+
 // Panic mocks base method.
 func (m *MockLogger) Panic(arg0 ...interface{}) {
 	m.ctrl.T.Helper()
@@ -428,6 +442,18 @@ func (mr *MockLoggerMockRecorder) Panicw(arg0 interface{}, arg1 ...interface{}) 
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Panicw", reflect.TypeOf((*MockLogger)(nil).Panicw), varargs...)
+}
+
+// SetLevel mocks base method.
+func (m *MockLogger) SetLevel(arg0 logging.Level) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetLevel", arg0)
+}
+
+// SetLevel indicates an expected call of SetLevel.
+func (mr *MockLoggerMockRecorder) SetLevel(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLevel", reflect.TypeOf((*MockLogger)(nil).SetLevel), arg0)
 }
 
 // Sync mocks base method.

--- a/logging/test/adapter_test.go
+++ b/logging/test/adapter_test.go
@@ -25,7 +25,7 @@ import (
 // outputLogCall is a call to output a log message.
 type outputLogCall struct {
 	// level is the level of the log message.
-	level logging.AdaptedLevel
+	level logging.Level
 	// message is the log message.
 	message string
 }
@@ -35,7 +35,7 @@ type Test_Adapter_Case struct {
 	// name is the name of the test case.
 	name string
 	// level is the level to use for the adapter
-	level logging.AdaptedLevel
+	level logging.Level
 	// inputLogs are the input logs to write to the adapter.
 	inputLogs []string
 	// expectedCalls are the expected calls to the logger.
@@ -51,27 +51,27 @@ func Test_Adapter(t *testing.T) {
 	for _, testCase := range []Test_Adapter_Case{
 		{
 			name:          "Debug",
-			level:         logging.AdaptedLevelDebug,
+			level:         logging.DebugLevel,
 			inputLogs:     []string{"debug message"},
-			expectedCalls: []outputLogCall{{level: logging.AdaptedLevelDebug, message: "debug message"}},
+			expectedCalls: []outputLogCall{{level: logging.DebugLevel, message: "debug message"}},
 		},
 		{
 			name:          "Info",
-			level:         logging.AdaptedLevelInfo,
+			level:         logging.InfoLevel,
 			inputLogs:     []string{"info message"},
-			expectedCalls: []outputLogCall{{level: logging.AdaptedLevelInfo, message: "info message"}},
+			expectedCalls: []outputLogCall{{level: logging.InfoLevel, message: "info message"}},
 		},
 		{
 			name:          "Warning",
-			level:         logging.AdaptedLevelWarn,
+			level:         logging.WarnLevel,
 			inputLogs:     []string{"warning message"},
-			expectedCalls: []outputLogCall{{level: logging.AdaptedLevelWarn, message: "warning message"}},
+			expectedCalls: []outputLogCall{{level: logging.WarnLevel, message: "warning message"}},
 		},
 		{
 			name:          "Error",
-			level:         logging.AdaptedLevelError,
+			level:         logging.ErrorLevel,
 			inputLogs:     []string{"error message"},
-			expectedCalls: []outputLogCall{{level: logging.AdaptedLevelError, message: "error message"}},
+			expectedCalls: []outputLogCall{{level: logging.ErrorLevel, message: "error message"}},
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -80,13 +80,13 @@ func Test_Adapter(t *testing.T) {
 			adapter := logging.NewAdapter(logger, testCase.level)
 			for _, expectedCall := range testCase.expectedCalls {
 				switch expectedCall.level {
-				case logging.AdaptedLevelDebug:
+				case logging.DebugLevel:
 					logger.EXPECT().Debug(expectedCall.message)
-				case logging.AdaptedLevelInfo:
+				case logging.InfoLevel:
 					logger.EXPECT().Info(expectedCall.message)
-				case logging.AdaptedLevelWarn:
+				case logging.WarnLevel:
 					logger.EXPECT().Warn(expectedCall.message)
-				case logging.AdaptedLevelError:
+				case logging.ErrorLevel:
 					logger.EXPECT().Error(expectedCall.message)
 				}
 			}

--- a/metrics/promhttp.go
+++ b/metrics/promhttp.go
@@ -25,7 +25,7 @@ import (
 // will be used to log any errors that occur while serving the metrics.
 func (m *metrics) Handler(logger logging.Logger) ht.Handler {
 	return promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{
-		ErrorLog:      logging.NewAdapter(logger, logging.AdaptedLevelError),
+		ErrorLog:      logging.NewAdapter(logger, logging.ErrorLevel),
 		ErrorHandling: promhttp.ContinueOnError,
 	})
 }

--- a/samples/basic/basic.go
+++ b/samples/basic/basic.go
@@ -59,14 +59,14 @@ func newBasicApp() (*BasicApp, error) {
 	app := &BasicApp{
 		Service: svc,
 	}
-	app.ConfigSetup(app.configSetup)
+	app.SetupConfig(app.setupConfig)
 	app.SetupWorkers(app.setupWorkers)
 	app.Cleanup(app.cleanup)
 	return app, nil
 }
 
-// configSetup sets up the configuration.
-func (a *BasicApp) configSetup(c config.Config) error {
+// setupConfig sets up the configuration.
+func (a *BasicApp) setupConfig(c config.Config) error {
 	return c.NewString("MESSAGE", "Hello, World!", "The message to print.")
 }
 

--- a/samples/basic/basic.go
+++ b/samples/basic/basic.go
@@ -29,10 +29,10 @@ import (
 //  - Define BasicApp, which embeds an instance of service.Service
 //  - Define newBasicApp, which initializes the application:
 //    - Create a new service.Service
-//    - Register the configuration setup hook `configSetup`
+//    - Register the configuration setup hook `setupConfig`
 //    - Register the worker setup hook `setupWorkers`
 //    - Register the cleanup hook `cleanup`
-//  - Define configSetup, which sets up the configuration:
+//  - Define setupConfig, which sets up the configuration:
 //    - Create a new string configuration variable `MESSAGE`
 //  - Define setupWorkers, which sets up the application workers:
 //    - Create a new HTTP server

--- a/service/README.md
+++ b/service/README.md
@@ -42,10 +42,10 @@ import (
 //  - Define BasicApp, which embeds an instance of service.Service
 //  - Define newBasicApp, which initializes the application:
 //    - Create a new service.Service
-//    - Register the configuration setup hook `configSetup`
+//    - Register the configuration setup hook `setupConfig`
 //    - Register the worker setup hook `setupWorkers`
 //    - Register the cleanup hook `cleanup`
-//  - Define configSetup, which sets up the configuration:
+//  - Define setupConfig, which sets up the configuration:
 //    - Create a new string configuration variable `MESSAGE`
 //  - Define setupWorkers, which sets up the application:
 //    - Create a new HTTP server
@@ -72,14 +72,14 @@ func newBasicApp() (*BasicApp, error) {
 	app := &BasicApp{
 		Service: svc,
 	}
-	app.ConfigSetup(app.configSetup)
+	app.SetupConfig(app.setupConfig)
 	app.SetupWorkers(app.setupWorkers)
 	app.Cleanup(app.cleanup)
 	return app, nil
 }
 
-// configSetup sets up the configuration.
-func (a *BasicApp) configSetup(c config.Config) error {
+// setupConfig sets up the configuration.
+func (a *BasicApp) setupConfig(c config.Config) error {
 	return c.NewString("MESSAGE", "Hello, World!", "The message to print.")
 }
 

--- a/service/hook.go
+++ b/service/hook.go
@@ -23,11 +23,11 @@ import (
 // CleanupFunc is a function that cleans up a service.
 type CleanupFunc func() error
 
-// ConfigSetupFunc is a function that sets up a service configuration.
-type ConfigSetupFunc func(c config.Config) error
-
 // PreRunFunc is a function that runs before the workers are started.
 type PreRunFunc func() error
+
+// SetupConfigFunc is a function that sets up a service configuration.
+type SetupConfigFunc func(c config.Config) error
 
 // SetupWorkersFunc is a function that sets up workers for the service.
 type SetupWorkersFunc func(workerGroup worker.Group) error
@@ -37,14 +37,14 @@ type SetupHTTPFunc func(server *http.Server) error
 
 type Hooks interface {
 	Cleanup(f CleanupFunc)
-	ConfigSetup(f ConfigSetupFunc)
 	PreRun(f PreRunFunc)
+	SetupConfig(f SetupConfigFunc)
 	SetupWorkers(f SetupWorkersFunc)
 	SetupHTTP(f SetupHTTPFunc)
 
 	invokeCleanup() error
-	invokeConfigSetup(c config.Config) error
 	invokePreRun() error
+	invokeSetupConfig(c config.Config) error
 	invokeSetupWorkers(workerGroup worker.Group) error
 	invokeSetupHTTP() (*http.Server, error)
 }
@@ -53,8 +53,8 @@ type Hooks interface {
 type hookstruct struct {
 	// cleanup is the cleanup hook.
 	cleanup CleanupFunc
-	// configSetup is the setup configuration hook.
-	configSetup ConfigSetupFunc
+	// setupConfig is the setup configuration hook.
+	setupConfig SetupConfigFunc
 	// prerun is the prerun hook.
 	prerun PreRunFunc
 	// setupWorkers is the setupWorkers hook.
@@ -73,9 +73,9 @@ func (h *hookstruct) Cleanup(f CleanupFunc) {
 	h.cleanup = f
 }
 
-// ConfigSetup registers a configuration setup hook.
-func (h *hookstruct) ConfigSetup(f ConfigSetupFunc) {
-	h.configSetup = f
+// SetupConfig registers a configuration setup hook.
+func (h *hookstruct) SetupConfig(f SetupConfigFunc) {
+	h.setupConfig = f
 }
 
 // PreRun registers a prerun hook.
@@ -101,10 +101,10 @@ func (h *hookstruct) invokeCleanup() error {
 	return nil
 }
 
-// invokeConfigSetup invokes the setup configuration hook.
-func (h *hookstruct) invokeConfigSetup(c config.Config) error {
-	if h.configSetup != nil {
-		return h.configSetup(c)
+// invokeSetupConfig invokes the setup configuration hook.
+func (h *hookstruct) invokeSetupConfig(c config.Config) error {
+	if h.setupConfig != nil {
+		return h.setupConfig(c)
 	}
 	return nil
 }

--- a/service/hook_test.go
+++ b/service/hook_test.go
@@ -55,8 +55,8 @@ func Test_hooks_InvokeCleanup(t *testing.T) {
 	}
 }
 
-// Test_hooks_InvokeConfigSetup tests that the config setup hook is invoked.
-func Test_hooks_InvokeConfigSetup(t *testing.T) {
+// Test_hooks_InvokeSetupConfig tests that the config setup hook is invoked.
+func Test_hooks_InvokeSetupConfig(t *testing.T) {
 	t.Parallel()
 	wasInvoked := false
 	h := &hookstruct{}

--- a/service/hook_test.go
+++ b/service/hook_test.go
@@ -27,7 +27,7 @@ import (
 func Test_hooks_NoHooks(t *testing.T) {
 	t.Parallel()
 	h := &hookstruct{}
-	if err := h.invokeConfigSetup(nil); err != nil {
+	if err := h.invokeSetupConfig(nil); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if err := h.invokeSetupWorkers(nil); err != nil {
@@ -60,11 +60,11 @@ func Test_hooks_InvokeConfigSetup(t *testing.T) {
 	t.Parallel()
 	wasInvoked := false
 	h := &hookstruct{}
-	h.ConfigSetup(func(c config.Config) error {
+	h.SetupConfig(func(c config.Config) error {
 		wasInvoked = true
 		return nil
 	})
-	if err := h.invokeConfigSetup(nil); err != nil {
+	if err := h.invokeSetupConfig(nil); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if !wasInvoked {

--- a/service/run.go
+++ b/service/run.go
@@ -30,7 +30,7 @@ func (s *Service) Run() (status error) {
 	}
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 	defer s.cancel()
-	if err := s.invokeConfigSetup(s.config); err != nil {
+	if err := s.invokeSetupConfig(s.config); err != nil {
 		return err
 	}
 	workerGroup := worker.NewGroup()

--- a/service/run_test.go
+++ b/service/run_test.go
@@ -65,14 +65,14 @@ func Test_run_MockMode(t *testing.T) {
 type Test_run_Hooks_Case struct {
 	name                   string
 	cleanupErr             error
-	configSetupErr         error
 	prerunErr              error
+	setupConfigErr         error
 	setupWorkersErr        error
 	setupHTTPErr           error
 	expectedErr            string
 	cleanupWasInvoked      bool
-	configSetupWasInvoked  bool
 	prerunWasInvoked       bool
+	setupConfigWasInvoked  bool
 	setupWorkersWasInvoked bool
 	setupHTTPWasInvoked    bool
 }
@@ -84,83 +84,83 @@ func Test_run_Hooks(t *testing.T) {
 		{
 			name:                   "no errors",
 			cleanupErr:             nil,
-			configSetupErr:         nil,
 			prerunErr:              nil,
+			setupConfigErr:         nil,
 			setupWorkersErr:        nil,
 			setupHTTPErr:           nil,
 			cleanupWasInvoked:      true,
-			configSetupWasInvoked:  true,
 			prerunWasInvoked:       true,
+			setupConfigWasInvoked:  true,
 			setupWorkersWasInvoked: true,
 			setupHTTPWasInvoked:    true,
 		},
 		{
 			name:                   "cleanup error",
 			cleanupErr:             fmt.Errorf("cleanup error"),
-			configSetupErr:         nil,
 			prerunErr:              nil,
+			setupConfigErr:         nil,
 			setupWorkersErr:        nil,
 			setupHTTPErr:           nil,
 			expectedErr:            "cleanup error",
 			cleanupWasInvoked:      true,
-			configSetupWasInvoked:  true,
 			prerunWasInvoked:       true,
+			setupConfigWasInvoked:  true,
 			setupWorkersWasInvoked: true,
 			setupHTTPWasInvoked:    true,
 		},
 		{
 			name:                   "config setup error",
 			cleanupErr:             nil,
-			configSetupErr:         fmt.Errorf("config setup error"),
 			prerunErr:              nil,
+			setupConfigErr:         fmt.Errorf("config setup error"),
 			setupWorkersErr:        nil,
 			setupHTTPErr:           nil,
 			expectedErr:            "config setup error",
 			cleanupWasInvoked:      false,
-			configSetupWasInvoked:  true,
 			prerunWasInvoked:       false,
+			setupConfigWasInvoked:  true,
 			setupWorkersWasInvoked: false,
 			setupHTTPWasInvoked:    false,
 		},
 		{
 			name:                   "prerun error",
 			cleanupErr:             nil,
-			configSetupErr:         nil,
 			prerunErr:              fmt.Errorf("prerun error"),
+			setupConfigErr:         nil,
 			setupWorkersErr:        nil,
 			setupHTTPErr:           nil,
 			expectedErr:            "prerun error",
 			cleanupWasInvoked:      true,
-			configSetupWasInvoked:  true,
 			prerunWasInvoked:       true,
+			setupConfigWasInvoked:  true,
 			setupWorkersWasInvoked: true,
 			setupHTTPWasInvoked:    true,
 		},
 		{
 			name:                   "setup workers error",
 			cleanupErr:             nil,
-			configSetupErr:         nil,
 			prerunErr:              nil,
+			setupConfigErr:         nil,
 			setupWorkersErr:        fmt.Errorf("setup workers error"),
 			setupHTTPErr:           nil,
 			expectedErr:            "setup workers error",
 			cleanupWasInvoked:      false,
-			configSetupWasInvoked:  true,
 			prerunWasInvoked:       false,
+			setupConfigWasInvoked:  true,
 			setupWorkersWasInvoked: true,
 			setupHTTPWasInvoked:    false,
 		},
 		{
 			name:                   "setup HTTP error",
 			cleanupErr:             nil,
-			configSetupErr:         nil,
 			prerunErr:              nil,
+			setupConfigErr:         nil,
 			setupWorkersErr:        nil,
 			setupHTTPErr:           fmt.Errorf("setup HTTP error"),
 			expectedErr:            "setup HTTP error",
 			cleanupWasInvoked:      true,
-			configSetupWasInvoked:  true,
 			prerunWasInvoked:       false,
+			setupConfigWasInvoked:  true,
 			setupWorkersWasInvoked: true,
 			setupHTTPWasInvoked:    true,
 		},
@@ -172,17 +172,17 @@ func Test_run_Hooks(t *testing.T) {
 				t.Fatalf("New returned an error: %v", err)
 			}
 			cleanupWasInvoked := false
-			configSetupWasInvoked := false
 			prerunWasInvoked := false
+			setupConfigWasInvoked := false
 			setupWorkersWasInvoked := false
 			setupHTTPWasInvoked := false
 			svc.Cleanup(func() error {
 				cleanupWasInvoked = true
 				return tc.cleanupErr
 			})
-			svc.ConfigSetup(func(config.Config) error {
-				configSetupWasInvoked = true
-				return tc.configSetupErr
+			svc.SetupConfig(func(config.Config) error {
+				setupConfigWasInvoked = true
+				return tc.setupConfigErr
 			})
 			svc.PreRun(func() error {
 				prerunWasInvoked = true
@@ -211,8 +211,8 @@ func Test_run_Hooks(t *testing.T) {
 			if cleanupWasInvoked != tc.cleanupWasInvoked {
 				t.Errorf("cleanup hook was invoked: %t", cleanupWasInvoked)
 			}
-			if configSetupWasInvoked != tc.configSetupWasInvoked {
-				t.Errorf("config setup hook was invoked: %t", configSetupWasInvoked)
+			if setupConfigWasInvoked != tc.setupConfigWasInvoked {
+				t.Errorf("config setup hook was invoked: %t", setupConfigWasInvoked)
 			}
 			if prerunWasInvoked != tc.prerunWasInvoked {
 				t.Errorf("prerun hook was invoked: %t", prerunWasInvoked)

--- a/version.go
+++ b/version.go
@@ -14,7 +14,7 @@
 
 package mu
 
-const version = "v0.1.10"
+const version = "v0.1.11"
 const _ = version
 
 // Version returns the version of mu.


### PR DESCRIPTION
## v0.1.11

* The `ConfigSetup` hook has been renamed to `SetupConfig`. **This is a
  breaking change.** To upgrade, call `SetupConfig` instead of `ConfigSetup`
  in your application.
* New `Level` and `SetLevel` methods for `logging.Logger`.
* New `WithLevel` option for `logging.New`.